### PR TITLE
Twdh 0.11.2 dev ecs solr image

### DIFF
--- a/docker/solr9/Dockerfile
+++ b/docker/solr9/Dockerfile
@@ -1,6 +1,10 @@
-FROM bitnami/solr:9.8.0
+FROM bitnamilegacy/solr:9.8.0
 
 USER root
+
+RUN mkdir -p /opt/bitnami/solr/server/solr/configsets/ckan/
+
+COPY solr-configset/ /opt/bitnami/solr/server/solr/configsets/ckan/conf/
 
 ADD https://repo1.maven.org/maven2/org/locationtech/jts/jts-core/1.17.1/jts-core-1.17.1.jar /opt/bitnami/solr/server/solr-webapp/webapp/WEB-INF/lib/jts-core-1.17.1.jar
 

--- a/docker/solr9/solr-configset/overwrite.schema.xml
+++ b/docker/solr9/solr-configset/overwrite.schema.xml
@@ -177,7 +177,12 @@ attribute with the form `ckan-X.Y` -->
     <field name="spatial_geom_*"  type="location_rpt" indexed="true" stored="true" multiValued="true" />
 
     <field name="spatial_simp" type="location_rpt" indexed="true" stored="true" multiValued="true"/>
-    <field name="place_keywords" type="text_general" indexed="true" stored="true" multiValued="true"/>
+    <field name="place_keywords" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="primary_tags" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="secondary_tags" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="linked_datasets" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="related_resources" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="supporting_url" type="text" indexed="true" stored="true" multiValued="true"/>
     
     <field name="indexed_ts" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
 


### PR DESCRIPTION
Probably don't actually want to merge this, but creating this PR to illustrate the changes.

Updated solr Dockerfile to use bitnami image with configset copied in - as opposed to old method of helm taking care of this - so that we can use this SOLR image with 0.11.2 on the zookeeper-less ECS system.